### PR TITLE
Fix issue with type suggestions not behaving correctly

### DIFF
--- a/client/cypress/integration/add-wordlist.spec.ts
+++ b/client/cypress/integration/add-wordlist.spec.ts
@@ -30,6 +30,13 @@ describe('Add Wordlist', () => {
     page.addWord({ word: 'Boo', forms: [], type: 'nouns' });
     page.getWordCards().should('have.length', '1');
   });
+
+  it('Should type a word and get a suggestion', () => {
+    page.typeWord({ word: 'Chicken', forms: [], type: 'noun' });
+    cy.wait(2000);
+    page.addWordButton().should('be.enabled');
+  });
+
   it('Should add a wordlist', () => {
     page.addWordList({
       name: 'funpack',

--- a/client/cypress/integration/view-wordlist.spec.ts
+++ b/client/cypress/integration/view-wordlist.spec.ts
@@ -34,6 +34,13 @@ describe('View WordList', () => {
     page.getWordCards().should('have.length', '11');
   });
 
+  it('Should type a word and get a suggestion', () => {
+    page.getWordCards().should('have.length', '10');
+    page.typeWord({ word: 'Chicken', forms: [], type: 'noun' });
+    cy.wait(2000);
+    page.addWordButton().should('be.enabled');
+  });
+
   it('Should delete a word', () => {
     page.getWordCards().should('have.length', '10');
     cy.get('.word-card').first().trigger('mouseover');

--- a/client/cypress/support/add-wordlist.po.ts
+++ b/client/cypress/support/add-wordlist.po.ts
@@ -63,4 +63,8 @@ export class AddWordListPage {
       // Select and click the desired value from the resulting menu
       .get(`mat-option[value="${type}"]`).click();
   }
+
+  typeWord(newWord) {
+    this.getWordName().type(newWord.word);
+  }
 }

--- a/client/cypress/support/view-wordlist.po.ts
+++ b/client/cypress/support/view-wordlist.po.ts
@@ -58,4 +58,9 @@ export class ViewWordListPage {
     this.selectMatSelectType(newWord.type);
     return this.addWordButton().click();
   }
+
+  typeWord(newWord) {
+    this.getWordName().type(newWord.word);
+  }
+
 }

--- a/client/src/app/words/add-word/add-word.component.html
+++ b/client/src/app/words/add-word/add-word.component.html
@@ -18,10 +18,10 @@
           <mat-label>Select a type</mat-label>
           <mat-select (selectionChange)="check()" id="select" [(ngModel)]="type">
             <mat-option>None</mat-option>
-            <mat-option value="nouns">{{suggested && type==='nouns' ? 'Noun (Suggested)': 'Noun'}}</mat-option>
-            <mat-option value="verbs">{{suggested && type==='verbs' ? 'Verb (Suggested)': 'Verb'}}</mat-option>
-            <mat-option value="adjectives">{{suggested && type==='adjectives' ? 'Adjective (Suggested)': 'Adjective'}}</mat-option>
-            <mat-option value="misc">{{suggested && type==='misc' ? 'Misc (Suggested)': 'Misc'}}</mat-option>
+            <mat-option value="nouns">{{suggested === 'noun' && type==='nouns' ? 'Noun (Suggested)': 'Noun'}}</mat-option>
+            <mat-option value="verbs">{{suggested === 'verb' && type==='verbs' ? 'Verb (Suggested)': 'Verb'}}</mat-option>
+            <mat-option value="adjectives">{{suggested === 'adjective' && type==='adjectives' ? 'Adjective (Suggested)': 'Adjective'}}</mat-option>
+            <mat-option value="misc">{{suggested === 'misc' && type==='misc' ? 'Misc (Suggested)': 'Misc'}}</mat-option>
           </mat-select>
         </mat-form-field>
 

--- a/client/src/app/words/add-word/add-word.component.ts
+++ b/client/src/app/words/add-word/add-word.component.ts
@@ -14,7 +14,7 @@ export class AddWordComponent implements OnInit {
   finished = false;
   type: string;
   cleared = false;
-  suggested = false;
+  suggested = '';
 
   added = false;
 
@@ -54,7 +54,8 @@ export class AddWordComponent implements OnInit {
           console.log('Retrieved type from API: ' + type);
           if (type === 'adjective' || type === 'verb' || type === 'noun') {
             this.type = `${type}s`;
-            this.suggested = true;
+            this.suggested = type;
+            this.check();
           } else { this.type = 'misc'; }
         }, err => console.log(err)
         );


### PR DESCRIPTION
Type suggestions would not enable the add word  button in the add wordlist component but it now does. In addition to this, it now shows 'suggested' on the right options instead of all of them. This fixes issue #62 

Co-authored-by: Richard Lussier <lussi036@morris.umn.edu>
Co-authored-by:  Joshua Eklund <eklun124@umn.edu>
Co-authored-by:  Jacob Jenness <jenne077@morris.umn.edu>
Co-authored-by:  Elena Lam <lam00071@morris.umn.edu>
Co-authored-by:  Biruk Mengistu <mengi024@morris.umn.edu>