### PR TITLE
Fix LGTM warnings

### DIFF
--- a/client/cypress/support/add-contextPack.po.ts
+++ b/client/cypress/support/add-contextPack.po.ts
@@ -1,4 +1,3 @@
-import { count } from 'console';
 import {ContextPack} from 'src/app/datatypes/contextPacks';
 
 export class AddContextPackPage {

--- a/client/src/app/wordlists/add-wordlist/add-wordlist.component.ts
+++ b/client/src/app/wordlists/add-wordlist/add-wordlist.component.ts
@@ -41,7 +41,7 @@ export class AddWordListComponent implements OnInit {
     this.finished =
       this.wordlistname.trim().length > 1 && (this.wordlistname.trim().match(/[^-a-zA-Z0-9 ]/)) === null;
     console.log(this.wordlistname.length);
-    console.log(this.wordlistname.match(/[^-a-zA-Z0-9- ]/));
+    console.log(this.wordlistname.match(/[^-a-zA-Z0-9 ]/));
     return this.finished;
   }
 


### PR DESCRIPTION
There were some unused imports and redundant regexes that had to be removed, so we removed them.