### PR TITLE
Fix added context packs

### DIFF
--- a/client/src/app/context-packs/add-contextPacks/add-contextPacks.component.ts
+++ b/client/src/app/context-packs/add-contextPacks/add-contextPacks.component.ts
@@ -70,7 +70,8 @@ export class AddContextPackComponent implements OnInit {
     if(!this.addContextPackForm.value.icon){
       this.addContextPackForm.value.icon = this.downloadURL ? this.downloadURL : '';
     }
-    this.cpService.addPack(this.addContextPackForm.value).subscribe(newID => {
+    const {name,icon,enabled} = this.addContextPackForm.value;
+    this.cpService.addPack({name,icon,enabled,wordlists:[]}).subscribe(newID => {
       this.snackBar.open('Added the ' + this.addContextPackForm.value.name + ' context pack successfully', null, {
         duration: 2000,
       });

--- a/client/src/app/services/contextPack-service/contextpack.service.ts
+++ b/client/src/app/services/contextPack-service/contextpack.service.ts
@@ -26,12 +26,12 @@ export class ContextPackService {
     return this.httpClient.get<ContextPack>(this.contextPackUrl + '/' + id);
   }
 
-  addPack(newPack: ContextPack): Observable<string> {
-    return this.httpClient.post<{id: string}>(this.contextPackUrl, newPack).pipe(map(res => res.id));
+  addPack(newPack: { name: string; icon: string; enabled: boolean; wordlists?: any[] }): Observable<string> {
+    return this.httpClient.post<{ id: string }>(this.contextPackUrl, newPack).pipe(map(res => res.id));
   }
 
   deletePack(id: string): Observable<string> {
-    return this.httpClient.delete<{id: string}>(this.contextPackUrl + '/' + id).pipe(map(res=>res.id));
+    return this.httpClient.delete<{ id: string }>(this.contextPackUrl + '/' + id).pipe(map(res => res.id));
   }
 
 }

--- a/client/src/testing/context-pack.service.mock.ts
+++ b/client/src/testing/context-pack.service.mock.ts
@@ -128,7 +128,7 @@ export class MockCPService extends ContextPackService {
       MockCPService.testCPs= MockCPService.testCPs.filter(cp=> cp._id!==id);
       return of(id);
     }
-    addPack(newPack: ContextPack): Observable<string> {
+    addPack(newPack: { name: string; icon: string; enabled: boolean; wordlists?: any[] }): Observable<string> {
       return of('fakeid');
     }
     includes(cp: ContextPack){


### PR DESCRIPTION
This pull request fixes a bug where you could not add wordlists to user created word lists.

Co-authored-by: Richard Lussier <lussi036@morris.umn.edu>
Co-authored-by:  Joshua Eklund <eklun124@umn.edu>
Co-authored-by:  Jacob Jenness <jenne077@morris.umn.edu>
Co-authored-by:  Elena Lam <lam00071@morris.umn.edu>
Co-authored-by:  Biruk Mengistu <mengi024@morris.umn.edu>